### PR TITLE
samsung: Remove devicesettings resources from lineage.dependencies

### DIFF
--- a/lineage.dependencies
+++ b/lineage.dependencies
@@ -1,6 +1,0 @@
-[
-  {
-    "repository": "android_packages_resources_devicesettings",
-    "target_path": "packages/resources/devicesettings"
-  }
-]


### PR DESCRIPTION
* Synced by default since LineageOS/android@9bd031c

Change-Id: I822298f856f4d1012f847a8be311310f5e51f2bb